### PR TITLE
Fix obs_comCam from not-working to working-to-first-order.

### DIFF
--- a/config/bias.py
+++ b/config/bias.py
@@ -1,0 +1,2 @@
+config.isr.doLinearize=False
+config.isr.doDefect=False

--- a/config/dark.py
+++ b/config/dark.py
@@ -1,0 +1,3 @@
+config.isr.doLinearize=False
+config.isr.doDefect=False
+config.repair.cosmicray.nCrPixelMax=100000

--- a/config/flat.py
+++ b/config/flat.py
@@ -1,0 +1,2 @@
+config.isr.doLinearize=False
+config.isr.doDefect=False

--- a/config/ingest.py
+++ b/config/ingest.py
@@ -1,6 +1,7 @@
 from lsst.obs.comCam.ingest import ComCamParseTask
 
 config.parse.retarget(ComCamParseTask)
+
 config.parse.translation = {
     'expTime': 'EXPTIME',
     'object': 'OBJECT',
@@ -14,6 +15,7 @@ config.parse.translation = {
 }
 config.parse.translators = {
     'visit': 'translate_visit',
+    'wavelength': 'translate_wavelength',
 }
 config.parse.defaults = {
     'object': "UNKNOWN",
@@ -25,14 +27,16 @@ config.register.columns = {
     'visit': 'int',
     'basename': 'text',
     'filter': 'text',
+    'date': 'text',
     'dateObs': 'text',
     'expTime': 'double',
     'raft': 'text',
-    'ccd': 'int',
+    'ccd': 'text',
     'object': 'text',
     'imageType': 'text',
     'testType': 'text',
     'lsstSerial': 'text',
     'field': 'text',
+    'wavelength': 'int',
 }
 config.register.visit = list(config.register.columns.keys())

--- a/config/ingestCalibs.py
+++ b/config/ingestCalibs.py
@@ -1,8 +1,8 @@
-from lsst.obs.monocam.ingest import MonocamCalibsParseTask
-config.parse.retarget(MonocamCalibsParseTask)
+from lsst.obs.comCam.ingest import ComCamCalibsParseTask
+config.parse.retarget(ComCamCalibsParseTask)
 
 config.register.columns = {'filter': 'text',
-                           'ccd': 'int',
+                           'ccd': 'text',
                            'calibDate': 'text',
                            'validStart': 'text',
                            'validEnd': 'text',

--- a/policy/comCamMapper.paf
+++ b/policy/comCamMapper.paf
@@ -88,7 +88,7 @@ exposures: {
 
 calibrations: {
     bias: {
-        template:    "bias/%(calibDate)s/bias-%(calibDate)s.fits.gz"
+        template:    "bias/%(calibDate)s/bias-%(ccd)s-%(calibDate)s.fits"
         python:      "lsst.afw.image.DecoratedImageF"
         persistable: "DecoratedImageF"
         storage:     "FitsStorage"
@@ -104,7 +104,7 @@ calibrations: {
         validEndName: validEnd
     }
     dark: {
-        template:    "dark/%(calibDate)s/dark-%(calibDate)s.fits.gz"
+        template:    "dark/%(calibDate)s/dark-%(ccd)s-%(calibDate)s.fits"
         python:      "lsst.afw.image.DecoratedImageF"
         persistable: "DecoratedImageF"
         storage:     "FitsStorage"
@@ -121,7 +121,7 @@ calibrations: {
 
     }
     flat: {
-        template:    "flat/%(filter)s/%(calibDate)s/flat_%(filter)s_%(calibDate)s.fits.gz"
+        template:    "flat/%(filter)s/%(calibDate)s/flat_%(ccd)s-%(filter)s_%(calibDate)s.fits"
         python:      "lsst.afw.image.DecoratedImageF"
         persistable: "DecoratedImageF"
         storage:     "FitsStorage"
@@ -139,7 +139,7 @@ calibrations: {
         validEndName: validEnd
     }
     fringe: {
-        template:    "fringe/%(filter)s/%(calibDate)s/fringe_%(filter)s_%(calibDate)s.fits.gz"
+        template:    "fringe/%(filter)s/%(calibDate)s/fringe_%(ccd)s-%(filter)s_%(calibDate)s.fits"
         python:      "lsst.afw.image.MaskedImageF"
         persistable: "MaskedImageF"
         storage:     "FitsStorage"

--- a/python/lsst/obs/comCam/ingest.py
+++ b/python/lsst/obs/comCam/ingest.py
@@ -3,7 +3,7 @@ import os
 import re
 from lsst.pipe.tasks.ingest import ParseTask
 from lsst.pipe.tasks.ingestCalibs import CalibsParseTask
-
+import lsst.log as lsstLog 
 
 EXTENSIONS = ["fits", "gz", "fz"]  # Filename extensions to strip off
 
@@ -18,15 +18,32 @@ class ComCamParseTask(ParseTask):
         super(ParseTask, self).__init__(config, *args, **kwargs)
 
     def getInfo(self, filename):
-        # Grab the basename
+        """ Get the basename and other data which is only available from the filename/path.
+        
+        This seems fragile, but this is how the teststand data will *always* be written out, 
+        as the software has been "frozen" as they are now in production mode.
+
+        Parameters
+        ----------
+        filename : `str`
+            The filename
+
+        Returns
+        -------
+        phuInfo : `dict`
+            Dictionary containing the header keys defined in the ingest config from the primary HDU
+        infoList : `list`
+            A list of dictionaries containing the phuInfo(s) for the various extensions in MEF files
+        """
         phuInfo, infoList = ParseTask.getInfo(self, filename)
 
         pathname, basename = os.path.split(filename)
         basename = re.sub(r"\.(%s)$" % "|".join(EXTENSIONS), "", basename)
         phuInfo['basename'] = basename
-        #
-        # Now pull the sensor ID from the path (no, it's not in the header)
-        #
+
+        # Now pull the acq type & jobID from the path (no, they're not in the header)
+        # the acq type is the type of test, eg flat/fe55/darks etc
+        # jobID is the test number, and corresponds to database entries in the eTraveller/cameraTestDB
         pathComponents = pathname.split("/")
         if len(pathComponents) < 0:
             raise RuntimeError("Path %s is too short to deduce raftID" % pathname)
@@ -34,23 +51,57 @@ class ComCamParseTask(ParseTask):
         if runId != phuInfo['run']:
             raise RuntimeError("Expected runId %s, found %s from path %s" % phuInfo['run'], runId, pathname)
 
-        phuInfo['raftId'] = raftId
-        phuInfo['field'] = acquisitionType
-        phuInfo['jobId'] = int(jobId)
+        phuInfo['raftId'] = raftId # also in the header - RAFTNAME
+        phuInfo['field'] = acquisitionType # NOT in the header
+        phuInfo['jobId'] = int(jobId) #  NOT in the header
         phuInfo['raft'] = 'R00'
-        phuInfo['ccd'] = sensorLocationInRaft
+        phuInfo['ccd'] = sensorLocationInRaft # NOT in the header
 
         return phuInfo, infoList
 
-    # Add entry to config.parse.translators in config/ingest.py if needed
-    def translate_ccd(self, md):
-        return md.get("sensorId")       # ... except that isn't actually present
+    def translate_wavelength(self, md):
+        """Translate wavelength provided by teststand readout.
 
-    # Add an entry to config.parse.translators in config/ingest.py if needed
+        The teststand driving script asks for a wavelength, and then reads the value back to ensure that
+        the correct position was moved to. This number is therefore read back with sub-nm precision.
+        Typically the position is within 0.005nm of the desired position, so we warn if it's not very
+        close to an integer value.
+
+        Future users should be aware that the HIERARCH MONOCH-WAVELENG key is NOT the requested value, and
+        therefore cannot be used as a cross-check that the wavelength was close to the one requested.
+        The only record of the wavelength that was set is in the original filename.
+
+        Parameters
+        ----------
+        md : `lsst.daf.base.PropertyList or PropertySet`
+            image metadata
+
+        Returns
+        -------
+        wavelength : `int`
+            The recorded wavelength as an int
+        """
+        raw_wl = md.get("MONOWL")
+        wl = int(round(raw_wl))
+        if abs(raw_wl-wl)>=0.1:
+            logger = lsstLog.Log.getLogger('obs.comCam.ingest')
+            logger.warn('Translated significantly non-integer wavelength; %s is more than 0.1nm from an integer value', raw_wl)
+        return wl
+
     def translate_visit(self, md):
         """Generate a unique visit from the timestamp
 
-        It would be better to use the 1000*runNo + seqNo, but the latter isn't currently set
+        It might be better to use the 1000*runNo + seqNo, but the latter isn't currently set
+
+        Parameters
+        ----------
+        md : `lsst.daf.base.PropertyList or PropertySet`
+            image metadata
+
+        Returns
+        -------
+        visit_num : `int`
+            Visit number, as translated
         """
         mjd = md.get("MJD-OBS")
         mmjd = mjd - 55197              # relative to 2010-01-01, just to make the visits a tiny bit smaller


### PR DESCRIPTION
The commit includes fixes to:
	Fix retargetting of task.
	Change ccd datatype from int to text
	Add wavelength translator and fix up the ingest
	Add config files for calib construction
	Add ccd number to template for calibs
	Add call to makeRawVisitInfo.getDarkTime() for getting the darkTime correctly
	Remove errant .gz suffixes from the policy file