### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/comCamMapper.yaml
+++ b/policy/comCamMapper.yaml
@@ -434,3 +434,5 @@ datasets:
     storage: PickleStorage
     tables: raw
     template: gain/%(run)s/gain%(ccd)s_%(run)s.pickle
+  apPipe_metadata:
+    template: apPipe_metadata/v%(visit)d_f%(filter)s.boost


### PR DESCRIPTION
This PR registers dataset mappings for configs and metadata persisted by `ApPipeTask`.